### PR TITLE
Add MIME type to stylesheet meta tag for robust URL parsing

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bootstrap w/ Parcel</title>
-    <link rel="stylesheet" href="scss/styles.scss" />
+    <link rel="stylesheet" type="text/css" href="scss/styles.scss" />
     <script type="module" src="js/main.js"></script>
   </head>
   <body>


### PR DESCRIPTION
I know it's not strictly necessary anymore, but I've always declared the MIME type so that the browser has no excuse but to parse the file correctly. I'm also pretty sure it speeds up the parsing mechanism (though I can't remember where I heard that).